### PR TITLE
결과 도출 시 react-confetti 폭죽 애니메이션 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "framer-motion": "^12.38.0",
         "next": "16.1.7",
         "react": "19.2.3",
+        "react-confetti": "^6.4.0",
         "react-dom": "19.2.3"
       },
       "devDependencies": {
@@ -5584,6 +5585,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
@@ -6357,6 +6373,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
+      "license": "BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "framer-motion": "^12.38.0",
     "next": "16.1.7",
     "react": "19.2.3",
+    "react-confetti": "^6.4.0",
     "react-dom": "19.2.3"
   },
   "devDependencies": {

--- a/src/components/DimensionShiftingToken.tsx
+++ b/src/components/DimensionShiftingToken.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { motion, useAnimation } from "framer-motion";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Confetti from "react-confetti";
 
 import { TOKEN_ASPECTS, type TokenAspect } from "@/constants/tokenAspects";
 
@@ -39,6 +40,10 @@ export function DimensionShiftingToken() {
   const [result, setResult] = useState<TokenAspect | null>(null);
   const [isShifting, setIsShifting] = useState(false);
 
+  const [isConfettiActive, setIsConfettiActive] = useState(false);
+  const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
+  const confettiTimerRef = useRef<number | null>(null);
+
   const aspectHex = useMemo(() => {
     if (!result) return null;
     return TAILWIND_BG_TO_HEX[result.tailwindColorClass] ?? null;
@@ -58,6 +63,24 @@ export function DimensionShiftingToken() {
   useEffect(() => {
     if (!isSpinning && !isShifting) startIdleRotation();
   }, [isSpinning, isShifting, startIdleRotation]);
+
+  useEffect(() => {
+    const updateSize = () => {
+      setWindowSize({ width: window.innerWidth, height: window.innerHeight });
+    };
+
+    updateSize();
+    window.addEventListener("resize", updateSize);
+    return () => window.removeEventListener("resize", updateSize);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (confettiTimerRef.current) {
+        window.clearTimeout(confettiTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleClick = useCallback(async () => {
     if (isSpinning || isShifting) return;
@@ -84,6 +107,16 @@ export function DimensionShiftingToken() {
     const aspect = pickRandomAspect();
     setResult(aspect);
 
+    // Show confetti right when the result is revealed.
+    if (confettiTimerRef.current) {
+      window.clearTimeout(confettiTimerRef.current);
+    }
+    setIsConfettiActive(true);
+    confettiTimerRef.current = window.setTimeout(() => {
+      setIsConfettiActive(false);
+      confettiTimerRef.current = null;
+    }, 3000);
+
     // Phase 2: expand into sphere then collapse back into a colored disk.
     setIsShifting(true);
     await controls.start({
@@ -103,6 +136,13 @@ export function DimensionShiftingToken() {
   const buttonTheme = result ? (TAILWIND_BG_TO_BUTTON[result.tailwindColorClass] ?? null) : null;
 
   const handleSpinAgain = useCallback(() => {
+    // Hide confetti immediately.
+    setIsConfettiActive(false);
+    if (confettiTimerRef.current) {
+      window.clearTimeout(confettiTimerRef.current);
+      confettiTimerRef.current = null;
+    }
+
     // 1. Reset the result to null
     setResult(null);
     // 2. Ensure spinning state is false so it goes back to the idle animation
@@ -136,6 +176,17 @@ export function DimensionShiftingToken() {
 
   return (
     <div className="flex w-full flex-col items-center justify-center gap-6 py-16">
+      {isConfettiActive ? (
+        <Confetti
+          width={windowSize.width}
+          height={windowSize.height}
+          recycle={false}
+          numberOfPieces={200}
+          run={isConfettiActive}
+          style={{ position: "fixed", top: 0, left: 0, zIndex: 50 }}
+        />
+      ) : null}
+
       <div
         role="button"
         tabIndex={isSpinning || isShifting || Boolean(result) ? -1 : 0}


### PR DESCRIPTION
Adds react-confetti animation when the token result is revealed. Runs for 3 seconds and stops immediately when 'Spin Again' is pressed.

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confetti celebration animation that triggers when tokens are revealed.
  * The celebration automatically plays for 3 seconds and then dismisses.
  * Animation responsively adjusts to window resizing for optimal visual experience.

* **Chores**
  * Added react-confetti library as a new dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->